### PR TITLE
Use inspect.signature when available instead of signature.getargspec.

### DIFF
--- a/rest_framework_recursive/fields.py
+++ b/rest_framework_recursive/fields.py
@@ -3,6 +3,18 @@ import importlib
 from rest_framework.fields import Field
 from rest_framework.serializers import BaseSerializer
 
+
+def _signature_parameters(func):
+    try:
+        inspect.signature
+    except AttributeError:
+        # Python 2.x
+        return inspect.getargspec(func).args
+    else:
+        # Python 3.x
+        return inspect.signature(func).parameters.keys()
+
+
 class RecursiveField(Field):
     """
     A field that gets its representation from its parent.
@@ -58,7 +70,7 @@ class RecursiveField(Field):
         super_kwargs = dict(
             (key, kwargs[key])
             for key in kwargs
-            if key in inspect.getargspec(Field.__init__).args
+            if key in _signature_parameters(Field.__init__)
         )
         super(RecursiveField, self).__init__(**super_kwargs)
 

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -214,3 +214,10 @@ class TestRecursiveField:
 
         # deserialization
         self.deserialize(RecursiveModelSerializer, representation)
+
+    def test_super_kwargs(self):
+        """RecursiveField.__init__ introspect the parent constructor to pass
+        kwargs properly. read_only is used used here to verify that the
+        argument is properly passed to the super Field."""
+        field = RecursiveField(default='a default value')
+        assert field.default == 'a default value'

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -217,7 +217,7 @@ class TestRecursiveField:
 
     def test_super_kwargs(self):
         """RecursiveField.__init__ introspect the parent constructor to pass
-        kwargs properly. read_only is used used here to verify that the
+        kwargs properly. default is used used here to verify that the
         argument is properly passed to the super Field."""
         field = RecursiveField(default='a default value')
         assert field.default == 'a default value'


### PR DESCRIPTION
signature.getargspec was deprecated in Python 3.0.

This commit also adds a test that ensures that the passing of arguments
to the super constrctor works as intended.

Fixed #15.