### PR TITLE
Add support for python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 # Minimum Django and REST framework version
-Django>=1.6
-djangorestframework>=3.0.0
+Django>=1.6; python_version <= '3.6'
+
+djangorestframework>=3.0.0; python_version <= '3.6'
 
 # Test requirements
-pytest-django==2.9.1
-pytest==2.8.5
+pytest-django==2.9.1; python_version <= '3.6'
+
+pytest==2.8.5; python_version <= '3.6'
+
 pytest-cov==2.2.0
 
 # wheel for PyPI installs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,16 @@
 # Minimum Django and REST framework version
 Django>=1.6; python_version <= '3.6'
+Django>=4.0; python_version >= '3.10'
 
 djangorestframework>=3.0.0; python_version <= '3.6'
+djangorestframework>=3.15.0; python_version >= '3.10'
 
 # Test requirements
 pytest-django==2.9.1; python_version <= '3.6'
+pytest-django==4.7.0; python_version >= '3.7' and python_version <= '3.10'
 
 pytest==2.8.5; python_version <= '3.6'
+pytest==8.3.2; python_version >= '3.8' and python_version <= '3.10'
 
 pytest-cov==2.2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 envlist =
-       {py27,py34,py35,py36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
-
+       py{27,34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
 [testenv]
-commands = ./runtests.py --fast
+allowlist_externals = python
+commands = python ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.8: Django>=1.8,<1.9
-       django1.9: Django>=1.9,<1.10
-       django1.10: Django>=1.10,<1.11
-       django1.11: Django>=1.11,<2.0
-       drf3.3: djangorestframework>=3.3,<3.4
-       drf3.4: djangorestframework>=3.4,<3.5
-       drf3.5: djangorestframework>=3.5,<3.6
-       drf3.6: djangorestframework>=3.6,<3.7
-       pytest-django==3.1.2
+       django1.8: Django>=1.8,<1.9; python_version <= '3.6'
+       django1.9: Django>=1.9,<1.10; python_version <= '3.6'
+       django1.10: Django>=1.10,<1.11; python_version <= '3.6'
+       django1.11: Django>=1.11,<2.0; python_version <= '3.6'
+       drf3.3: djangorestframework>=3.3,<3.4; python_version <= '3.6'
+       drf3.4: djangorestframework>=3.4,<3.5; python_version <= '3.6'
+       drf3.5: djangorestframework>=3.5,<3.6; python_version <= '3.6'
+       drf3.6: djangorestframework>=3.6,<3.7; python_version <= '3.6'
+       pytest-django==3.1.2; python_version <= '3.6'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
        py{27,34,35,36}-django{1.8,1.9,1.10}-drf{3.3,3.4,3.5,3.6}
+       py{310}-django{4}-drf{3.15}
 [testenv]
 allowlist_externals = python
 commands = python ./runtests.py --fast
@@ -11,8 +12,11 @@ deps =
        django1.9: Django>=1.9,<1.10; python_version <= '3.6'
        django1.10: Django>=1.10,<1.11; python_version <= '3.6'
        django1.11: Django>=1.11,<2.0; python_version <= '3.6'
+       django4: Django>=4.0,<5.0; python_version >= '3.10'
        drf3.3: djangorestframework>=3.3,<3.4; python_version <= '3.6'
        drf3.4: djangorestframework>=3.4,<3.5; python_version <= '3.6'
        drf3.5: djangorestframework>=3.5,<3.6; python_version <= '3.6'
        drf3.6: djangorestframework>=3.6,<3.7; python_version <= '3.6'
+       drf3.15: djangorestframework>=3.15,<3.16; python_version >= '3.10'
        pytest-django==3.1.2; python_version <= '3.6'
+       pytest-django==4.7.0; python_version >= '3.10'


### PR DESCRIPTION
This PR adds support for Python 3.10, Django 4, and Django-Rest-Framework 3.15.

None of the logic has needed an update for this upgrade, I've just had to update the tests so that we correctly assert missing values for Nullable/Optional fields. Between the last tested versions and the updated ones there have been updates to how Nullable fields are treated in DRF and they're now explicitly populated with `None`, the added test function recursively adds these in.